### PR TITLE
Add void/str function

### DIFF
--- a/src/dvlopt/void.cljc
+++ b/src/dvlopt/void.cljc
@@ -14,6 +14,7 @@
                             assoc-in
                             merge
                             merge-with
+                            str
                             update
                             update-in]))
 
@@ -436,6 +437,27 @@
                           {}
                           node))
     node))
+
+
+
+
+(defn str
+
+  "Just like standard `str` but calling with only nils results in a nil value being returned
+
+  ```clojure
+  (str nil nil nil)
+
+  nil
+
+
+  (str nil 1 2 nil)
+
+  \"12\""
+
+  [& xs]
+  (when (seq (remove nil? xs))
+    (apply clj/str xs)))
 
 
 

--- a/test/dvlopt/void_test.cljc
+++ b/test/dvlopt/void_test.cljc
@@ -9,6 +9,7 @@
                             assoc-in
                             merge
                             merge-with
+                            str
                             update
                             update-in]))
 
@@ -198,6 +199,23 @@
            (void/prune {:a {:b 42
                             :c {:d nil}}}))
         "Non-nil leaves are kept intact"))
+
+
+
+
+(t/deftest str
+
+  (t/is (nil? (void/str nil))
+        "Calling str with nil returns nil")
+
+  (t/is (nil? (void/str nil nil nil))
+        "Calling str with multiple nils returns nil")
+
+  (t/is (= "foobar" (void/str "foo" nil "bar"))
+        "Calling str with non-nil arguments returns non-nil")
+
+  (t/is (= "" (void/str ""))
+        "Calling str with empty string returns empty string"))
 
 
 


### PR DESCRIPTION
Hey, thanks for this library! I've found that the default `str` functionality doesn't always work well in conjunction with this library because I'd like to have `(str nil)` get "voided" by your other functions. This provides a `void/str` function that does just that. Let me know if you'd like any changes or if you don't feel like this belongs in the library.

Cheers!